### PR TITLE
Pandoc syntax highlighting

### DIFF
--- a/_build/Makefile
+++ b/_build/Makefile
@@ -18,7 +18,7 @@ pandoc = /usr/bin/pandoc
 # variables
 mkdir = @mkdir -p $(dir $@)
 out = _out
-pandoc_options=--from markdown-tex_math_dollars --to html5
+pandoc_options=--from markdown-tex_math_dollars --to html5 --syntax-definition=smallbasic.xml
 bas = $(patsubst layouts/%.html, $(out)/%.bas, $(wildcard layouts/*.html))
 pages = $(patsubst pages/%.markdown, $(out)/pages3/%.html, $(wildcard pages/*.markdown))
 posts = $(patsubst posts/%.markdown, $(out)/posts3/%.html, $(wildcard posts/*.markdown))

--- a/_build/pages/android.markdown
+++ b/_build/pages/android.markdown
@@ -37,7 +37,7 @@ All of the above UI elements are written in SmallBASIC, see [main.bas](https://g
 
 To use the following services, your program must start with the following two lines:
 
-```
+```smallbasic
 option predef load modules
 import android
 ```
@@ -48,7 +48,7 @@ The first line tell SmallBASIC to dynamically load runtime modules. The second l
 
 GPS_ON
 
-```
+```smallbasic
 android.gps_on()
 ```
 
@@ -56,7 +56,7 @@ Instructs the system to commence recording location information. Note: This reli
 
 GPS_OFF
 
-```
+```smallbasic
 android.gps_off()
 ```
 
@@ -64,7 +64,7 @@ Turns off recording of location information.
 
 LOCATION
 
-```
+```smallbasic
 l = android.location()
 ```
 
@@ -86,7 +86,7 @@ For more details, see: <https://developer.android.com/reference/android/location
 
 SENSOR_ON
 
-```
+```smallbasic
 const SensorAccelerometer = 0
 const SensorMagneticField = 1
 const SensorGyroscope = 2
@@ -99,7 +99,7 @@ Enables the given sensor (currently only one may be enabled at a time). Throws a
 
 SENSOR_OFF
 
-```
+```smallbasic
 android.sensor_off()
 ```
 
@@ -107,7 +107,7 @@ Disables any active sensor.
 
 SENSOR
 
-```
+```smallbasic
 s = android.sensor()
 ```
 
@@ -131,7 +131,7 @@ Notes:
 
 TTS_PITCH
 
-```
+```smallbasic
 android.tts_pitch(n)
 ```
 
@@ -139,7 +139,7 @@ Sets the voice pitch (default is 1.0).
 
 TTS_RATE
 
-```
+```smallbasic
 android.tts_rate(n)
 ```
 
@@ -147,7 +147,7 @@ Sets the rate of speaking (default is 1.0)
 
 TTS_LANG
 
-```
+```smallbasic
 android.tts_lang(s)
 ```
 
@@ -155,7 +155,7 @@ Sets the locale, for example "en", "de", "fr" for English, German, France. May c
 
 TTS_OFF
 
-```
+```smallbasic
 android.tts_off()
 ```
 
@@ -163,7 +163,7 @@ Turns off text to speech output.
 
 SPEAK
 
-```
+```smallbasic
 android.speak(text)
 ```
 

--- a/_build/pages/escape.markdown
+++ b/_build/pages/escape.markdown
@@ -31,7 +31,7 @@ SmallBASIC supports a number of escape codes for controlling the display. The co
 
 Instead of `\e` the command CHR(27) is useful for obtaining and printing the escape character.
 
-```Freebasic
+```smallbasic
 PRINT CHR(27) + "[1mTHIS IS BOLD" + CHR(27) + "[0m"
 PRINT CHR(27) + "[3mThis is italic"  + CHR(27) + "[0m"
 PRINT CHR(27) + "[4mThis is underline"
@@ -47,7 +47,7 @@ The EscapeCode Unit makes it easier to use escape codes and to deal with differe
 
 Here an example on how to use the unit:
 
-```Freebasic
+```smallbasic
 ' SmallBASIC 12.25
 ' Example for using UNIT "EscapeCodes"
 ' For more information see: https://smallbasic.github.io/pages/escape.html

--- a/_build/pages/network.markdown
+++ b/_build/pages/network.markdown
@@ -7,7 +7,7 @@ Network programming
 
 Use the prefix "HTTP:" with the OPEN command to open a network HTTP connection. You can then use the file number with the TLOAD command to read the data.
 
-```
+```smallbasic
 print "DuckDuckGo Search"
 while 1
   print '<=== when cycle around need to isolate input prompt
@@ -43,7 +43,7 @@ wend
 
 Use the prefix "HTTP:" with the OPEN command to open an image file over the network. You can then pass the file number to the IMAGE command. This returns an system object which can then be used to manipulate images in the graphical version of SmallBASIC.
 
-```
+```smallbasic
 ' open some random image I found on the net
 open "http://img2.wikia.nocookie.net/__cb20150113215904/farmville/images/9/92/Lumberjack_Gnome-icon.png" as #1
 
@@ -85,7 +85,7 @@ pause true
 
 Use the prefix "SOCL:" with the OPEN command to open a network socket. You can then use the file number with other input/output commands to interact with the connection.
 
-```
+```smallbasic
 open "SOCL:192.168.178.76:8080" as #1
 print #1, "time"
 lineinput #1, s
@@ -95,7 +95,7 @@ close #1
 
 If you omit the host name in the SOCL: string passed to the OPEN command, SmallBASIC will listen for connections from another host/process.
 
-```
+```smallbasic
 rem Print a date string like '29 SEP 2018 09:31:49 ACST'
 func get_time
   local today = julian(date)
@@ -127,7 +127,7 @@ In addition to the graphical and command line versions of SmallBASIC, there is a
 
 You launch the web SmallBASIC in a folder containing one or more SmallBASIC programs, you then point your browser to a URL formulated from the listening port number and the SmallBASIC program name. For example:
 
-```
+```smallbasic
 $ ls cats.bas  # program cats.bas exists in the current folder
 $ sbasicw
 Starting SmallBASIC web server on port:8080
@@ -135,7 +135,7 @@ Starting SmallBASIC web server on port:8080
 
 In your Web Browser:
 
-```
+```smallbasic
 http://localhost:8080/cats.bas
 Output from cats.bas displayed in the web browser.
 

--- a/_build/pages/plugins_clipboard.markdown
+++ b/_build/pages/plugins_clipboard.markdown
@@ -9,7 +9,7 @@ Clipboard is a simple plugin to copy and paste text between your SmallBASIC prog
 The plugin can be used by importing it with `import clipboard`. A simple "Hello World" program looks like this:
 
 
-```
+```smallbasic
 import clipboard
 
 print clipboard.paste()

--- a/_build/pages/plugins_gifenc.markdown
+++ b/_build/pages/plugins_gifenc.markdown
@@ -9,7 +9,7 @@ Gifenc lets you create simple animated gif images. It is based on a c library cr
 The plugin can be used by importing it with `import gifenc`. A simple program creating a moving stripe pattern with 8 frames looks like this:
 
 
-```
+```smallbasic
 import gifenc as ge
 
 const w = 120

--- a/_build/pages/plugins_nuklear.markdown
+++ b/_build/pages/plugins_nuklear.markdown
@@ -26,7 +26,7 @@ If you are working in Windows, then start your program with:
 
 The following code shows how to create your first "Hello World" window.
 
-```
+```smallbasic
 option predef grmode 640x480    ' Set window size
 
 import nuklear as nk            ' Import Nuklear plugin
@@ -44,7 +44,7 @@ With `nk.windowBegin()` a window will be created, if not already present. Additi
 
 ## Placing a button
 
-```
+```smallbasic
 option predef grmode 640x480
 
 import nuklear as nk
@@ -69,7 +69,7 @@ Before you can add a button, you have to define a layout which can hold the GUI 
 
 ## Displaying two radio buttons
 
-```
+```smallbasic
 option predef grmode 640x480
 
 import nuklear as nk
@@ -98,7 +98,7 @@ Because `nk.layoutRow("dynamic", 90, 2)` is this time set to "2" two elements ar
 
 ## Dynamic rows vs. static rows
 
-```
+```smallbasic
 option predef grmode 640x480
 
 import nuklear as nk
@@ -133,7 +133,7 @@ If you run this example and change the size of the window with the mouse, you ca
 
 ## Show input boxes with labels - More flexible row layout
 
-```
+```smallbasic
 option predef grmode 640x480
 
 import nuklear as nk
@@ -174,7 +174,7 @@ When using `nk.layoutRowBegin(...)` the end of the definition for a row has to b
 
 Caution: `menuItem()` is not yet working probably. This will be fixed with the next release.
 
-```
+```smallbasic
 option predef grmode 640x480
 
 import nuklear as nk
@@ -208,7 +208,7 @@ The example above will display a menu with one entry called "Menu". When clicked
 
 ### Draw basic shapes
 
-```
+```smallbasic
 option predef grmode 640x480
 
 import nuklear as nk
@@ -263,7 +263,7 @@ checkboxValue: actual value of the checkbox
 
 Creates a checkbox with the name _Name_. State of the checkbox is stored in _checkboxValue_.
 
-```
+```smallbasic
 checkA = {value: false}
 ...
 nk.Checkbox("Checkbox A", checkA)
@@ -290,7 +290,7 @@ color: color of the colorpicker
 
 Creates a colorpicker. The color picked by the user is stored in color.value as a string.
 
-```
+```smallbasic
 colorPicker = {value: "#ff0000"}
 ...
 nk.colorPicker(colorPicker)
@@ -305,7 +305,7 @@ comboValue (map): settings of combobox
 
 Creates a combobox. The number of the selected combobox is stored in _comboValue.value_.
 
-```
+```smallbasic
 comboA = {value: 1, items: ["A", "B", "C"]}
 nk.combobox(comboA)
 ```
@@ -319,7 +319,7 @@ triggerX, triggerY, triggerW, triggerH: Trigger area in pixel
 
 Creates an contextual menu. Right-click in the trigger area will open a menu.
 
-```
+```smallbasic
 [x, y, w, h] = nk.widgetBounds()
 if nk.contextualBegin(100, 100, x, y, w, h) then
     nk.layoutRow("dynamic", 30, 1)
@@ -358,7 +358,7 @@ editValue: Stores the actual text
 
 Creates an input box. The content of the input box is stored in _editValue.value_.
 
-```
+```smallbasic
 editA = {value: ""}
 ...
 nk.edit("field", editA)
@@ -383,7 +383,7 @@ Style (String): "", "border"
 
 Groups several elements. The group can be surrounded by a border.
 
-```
+```smallbasic
 nk.groupBegin("Group 1", "border")
     nk.layoutRow("dynamic", 30, 1)
     nk.label("Radio buttons:")
@@ -414,7 +414,7 @@ color (string): hex color, i.e "#ff0000"
 
 Creates a label.
 
-```
+```smallbasic
 nk.label("Left label")
 nk.label("Centered label", "centered")
 nk.label("Right label", "right")
@@ -523,7 +523,7 @@ modifiable: true or false (default: false)
 
 Displays a progress bar. The length of the bar is given by _progressValue.value_. Set _modifiable_ to true, if you want to use the progress bar as a slider to change the value.
 
-```
+```smallbasic
 progress.value = 5
 ...
 nk.progress(progress, 10, false)
@@ -541,7 +541,7 @@ stepSizeByMoving: Stepsize when click + hold + moving the mouse
 
 Displays an input box for numbers. The actual value is stored in _propertyValue.value_.
 
-```
+```smallbasic
 property = {value: 6}
 ...
 nk.property("Property", 1, property, 10, 0.25, 0.5)
@@ -575,7 +575,7 @@ selectValue: value of the item
 
 Creates a list of items, which can be selected similar to a checkbox. The actual value of the selectable is stored in _selectValue.value_
 
-```
+```smallbasic
 selectA = {value: false}
 selectB = {value: true}
 ...
@@ -595,7 +595,7 @@ stepSize: step size of the slider when moving with the mouse
 
 Displays a slider. The slider position is given by _sliderValue.value_
 
-```
+```smallbasic
 sliderValue  = {value: 5}
 ...
 nk.slider(1, sliderValue, 10, .5)
@@ -632,7 +632,7 @@ TooltipValue (String): Text of the tooltip
 
 Prints a tooltip.
 
-```
+```smallbasic
 edit = {value: "Edit text"}
 ...
 nk.layoutRow("dynamic", 30, 1)
@@ -657,7 +657,7 @@ name (String): name of tree element
 
 Creates a tree.
 
-```
+```smallbasic
 nk.layoutRow("dynamic", 30, 1)
 if nk.treePush("tab", "Tree Tab") then
     if nk.treePush("node", "Tree Node 1") then
@@ -715,7 +715,7 @@ w,h: width and height of the widget
 
 Returns the position and the dimensions of a widget.
 
-```
+```smallbasic
 edit = {value: "Edit text"}
 ...
 nk.layoutRow("dynamic", 30, 1)

--- a/_build/pages/plugins_pigpio.markdown
+++ b/_build/pages/plugins_pigpio.markdown
@@ -23,7 +23,7 @@ Connect the resistor to pin 4 and the LED to ground of the Raspberry Pi.
 
 To let the LED blink the following SmallBASIC program can be used.
 
-```freebasic
+```smallbasic
 import SmallBasicPIGPIO as gpio
 
 ' LED is connected to pin GPIO4
@@ -45,7 +45,7 @@ next
 
 The plugin supports Pulse Width Modulation (PWM). Using this technique the intensity of the LED can tuned as shown in the next example.
 
-```freebasic
+```smallbasic
 import SmallBasicPIGPIO as gpio
 
 ' LED is connected to pin GPIO4
@@ -80,7 +80,7 @@ In the following image you see the wiring of a push button. When you press the b
 
 To read the state of the button, the following example program can be used.
 
-```freebasic
+```smallbasic
 import SmallBasicPIGPIO as gpio
 
 const PIN_GPIO4 = 4
@@ -116,7 +116,7 @@ For running this example, you need a SSD1306 compatible OLED display. OLEDs with
 
 The following example shows how to use basic graphic commands to draw lines or print text.
 
-```freebasic
+```smallbasic
 import SmallBasicPIGPIO as gpio
 
 gpio.OLED1_Open()

--- a/_build/pages/trycatch.markdown
+++ b/_build/pages/trycatch.markdown
@@ -24,7 +24,7 @@ The THROW command (previously known as __RTE__) is used to initiate a catch-able
  
 **Example**
 
-```
+```smallbasic
 try
  open "com2000:" AS #1
 catch err

--- a/_build/pages/units_css_color_names.markdown
+++ b/_build/pages/units_css_color_names.markdown
@@ -13,7 +13,7 @@ can be used to display all colors and there names.
 
 ## Using the unit
 
-```Freebasic
+```smallbasic
 Import crgb as c
 
 Color c.Black, c.Lime

--- a/_build/pages/units_qrcode.markdown
+++ b/_build/pages/units_qrcode.markdown
@@ -10,7 +10,7 @@ Please save the unit in the same directory as your basic file.
 
 ## Using the unit
 
-```Freebasic
+```smallbasic
 import qrcode
 
 color 1, 15

--- a/_build/reference/1015-console-definekey.markdown
+++ b/_build/reference/1015-console-definekey.markdown
@@ -37,7 +37,7 @@ Keycodes for PC keyboard
 
 Example 1: Bind keystroke for left and right arrow key
 
-~~~
+```smallbasic
 defineKey 0xFF04, Increase      'Left arrow
 defineKey 0xFF05, Decrease      'Right arrow
 
@@ -54,18 +54,18 @@ while(1)
     at 0,0: print t + ": " + x + "    "
     delay(50)
 wend
-~~~
+```
 
 
 Example 2: Unbind a keystroke
 
-```
+```smallbasic
 DEFINEKEY 0xFF04, 0
 ```
 
 Example 3: Etch-a-Sketch
 
-~~~
+```smallbasic
 ' DEFINEKEY demo.bas  SmallBASIC 0.12.2 [B+=MGA] 2016-03-30
 'remember Etch-A-Sketch?
 'definekey key,sub
@@ -129,11 +129,11 @@ end
 sub quit
   stop
 end
-~~~
+```
 
 Example 4: This example is outdated and just a reference for buttons in PALM OS
 
-~~~
+```smallbasic
 ' Note:
 ' * You may Include "definekey_const.bas" file in another file to make your code more clear.
 '
@@ -220,4 +220,4 @@ Const DK_MK_RELEASE = 0xFFC3
 Const DK_MK_WHEEL   = 0xFFC4
 Const DK_MK_FIRST   = DK_MK_PUSH
 Const DK_MK_LAST    = DK_MK_WHEEL
-~~~
+```

--- a/_build/reference/521-console-at.markdown
+++ b/_build/reference/521-console-at.markdown
@@ -4,7 +4,7 @@
 
 Moves the console cursor to the specified position. x,y are in pixels.
 
-```
+```smallbasic
 at 100,100
 print "This text starts at pixel 100,100"
 ```

--- a/_build/reference/524-console-cls.markdown
+++ b/_build/reference/524-console-cls.markdown
@@ -4,7 +4,7 @@
 
 Clears the screen.
 
-```
+```smallbasic
 print "Test"
 CLS
 ```

--- a/_build/reference/525-console-form.markdown
+++ b/_build/reference/525-console-form.markdown
@@ -72,7 +72,7 @@ The type attribute can be one of the following:
 
 ### Example 1: Creating a push button using callback function
 
-```
+```smallbasic
 button.type = "button"
 button.x = 120
 button.y = 120
@@ -99,7 +99,7 @@ end
 
 ### Example 2: Creating a push button using doEvents result
 
-```
+```smallbasic
 button.type = "button"
 button.x = 120
 button.y = 120
@@ -125,7 +125,7 @@ f.close()
 
 ### Example 3: Creating a label
 
-```
+```smallbasic
 l.type = "label"
 l.x = 120
 l.y = 120
@@ -145,7 +145,7 @@ f.close()
 
 ### Example 4: Creating a link to an external website
 
-```
+```smallbasic
 l.type = "link"
 l.x = 120
 l.y = 120
@@ -167,7 +167,7 @@ f.close()
 
 ### Example 5: Creating a listbox
 
-```
+```smallbasic
 l.type = "listbox"
 l.x = 120
 l.y = 120
@@ -196,7 +196,7 @@ f.close()
 
 ### Example 6: Creating a dropdown listbox
 
-```
+```smallbasic
 l.type = "choice"
 l.x = 120
 l.y = 120
@@ -224,7 +224,7 @@ f.close()
 
 ### Example 7: Creating a text input field
 
-```
+```smallbasic
 t.type = "text"
 t.x = 120
 t.y = 120
@@ -266,7 +266,7 @@ end
 In this example a callback function will be used. If you want to use the doEvents result instead,
 have a look at example 2.
 
-```
+```smallbasic
 ' Create a simple button and save it as png
 ' If you have already an image for you button,
 ' this part is not necessary.
@@ -301,7 +301,7 @@ end
 
 ### Example 9: One more example
 
-```
+```smallbasic
 f.handleKeys = 0
 ' create some buttons
 button1.y = 120

--- a/_build/reference/527-console-input.markdown
+++ b/_build/reference/527-console-input.markdown
@@ -6,14 +6,14 @@ Reads text from keyboard and stores it in the variable `var`. The string `prompt
 
 ### Example 1: Using a single var
 
-```
+```smallbasic
 input "How old are you?", age
 print age
 ```
 
 ### Example 2: Using multiple vars
 
-```
+```smallbasic
 input "Input three numbers: ", a, b, c   ' Input i.e. 1,2,3
 print a, b, c
 ```

--- a/_build/reference/528-console-lineinput.markdown
+++ b/_build/reference/528-console-lineinput.markdown
@@ -6,14 +6,14 @@ Reads a whole text line from file or console and stores it in the string `var`. 
 
 ### Example 1: Read from console
 
-```
+```smallbasic
 LINEINPUT S
 PRINT S
 ```
 
 ### Example 2: Read from file
 
-```
+```smallbasic
 ' create a file
 open "File.txt" for output as #1
 

--- a/_build/reference/529-console-linput.markdown
+++ b/_build/reference/529-console-linput.markdown
@@ -6,14 +6,14 @@ Reads a whole text line from file or console and stores it in the string `var`. 
 
 ### Example 1: Read from console
 
-```
+```smallbasic
 LINPUT S
 PRINT S
 ```
 
 ### Example 2: Read from file
 
-```
+```smallbasic
 ' create a file
 open "File.txt" for output as #1
 

--- a/_build/reference/530-console-locate.markdown
+++ b/_build/reference/530-console-locate.markdown
@@ -8,14 +8,14 @@ See AT for positioning the cursor in pixel.
 
 ### Example 1:
 
-```
+```smallbasic
 locate 5,7
 print "text at row 5 and column 7"
 ```
 
 ### Example 2: Print text always in center of window
 
-```
+```smallbasic
 ' Define functions to calculate lines and columns
 Def lines() = (Ymax + 1) \ Txth("x")   ' maximum lines in window
 Def columns() = (Xmax + 1) \ Txtw("x") ' maximum columns in window
@@ -67,7 +67,7 @@ Wend
 ```
 ### Example 3: Print ASCII table
 
-```
+```smallbasic
 ' LOCATE MOD CHR ASC.bas  SmallBASIC 0.12.2 [B+=MGA] 2016-03-23
 '
 ' LOCATE row, column: sets the next print location on screen,

--- a/_build/reference/531-console-logprint.markdown
+++ b/_build/reference/531-console-logprint.markdown
@@ -7,7 +7,7 @@ The nicely formated output of your program will not be messed up by the log mess
 
 ### Example:
 
-```
+```smallbasic
 logprint "Error message goes to stderr"
 print "Normal text goes to sdtout"
 ```
@@ -29,21 +29,21 @@ In Linux sdterr can be easily redirected to a file (i.e. error.txt):
 
 Start the basic-file from a command line:
 
-```
+```smallbasic
 SDL-version    : sbasicg test.bas 2>error.txt
 Console-version: sbasic test.bas 2>error.txt
 ```
 
 with test.bas:
 
-```
+```smallbasic
 logprint "Error message goes to stderr"
 print "Normal text goes to sdtout"
 ```
 
 Afer running the program the file error.txt will appear with the content:
 
-```
+```smallbasic
 Error message goes to stderr
 ```
 

--- a/_build/reference/533-console-pen.markdown
+++ b/_build/reference/533-console-pen.markdown
@@ -6,7 +6,7 @@ Enables/Disables the pen/mouse/tap mechanism. See function `n = PEN(value)` for 
 
 ### Example
 
-```
+```smallbasic
 pen on
 
 print "Press left mouse button or tab screen. Press q to quit."

--- a/_build/reference/534-console-play.markdown
+++ b/_build/reference/534-console-play.markdown
@@ -24,13 +24,13 @@ To play a sound file use `file://filename` as string. When playing on background
 
 ### Example 1: Play a note
 
-```
+```smallbasic
 play "L2A"    ' note A with length 1/2
 ```
 
 ### Example 2: Play multiple notes
 
-```
+```smallbasic
 ' Set volume to 50%
 play "V10"  
 ' Play Menuet by J. Sebastian Bach
@@ -39,14 +39,14 @@ play "T180L8O3MN O4D4O3MLGABO4C O4D4O3MNG4MLG4 O4MNE4MLCDEF# O4G4O3MNG4MLG4 O4MN
 
 ### Example 3: Play notes on background
 
-```
+```smallbasic
 play "MBL2A"    ' note A with length 1/2 on background
 pause           ' make sure, that program will not end
 ```
 
 ### Example 4: Play a sound file
 
-```
+```smallbasic
 ' Copy a mp3 file to the working directory and name it test.mp3
 
 play "file://test.mp3"

--- a/_build/reference/535-console-print.markdown
+++ b/_build/reference/535-console-print.markdown
@@ -10,7 +10,7 @@ To gain more control of where your next PRINT statement will be placed on screen
 
 ### Example 1: Basic usage
 
-```
+```smallbasic
 print 1                             ' Output: 1
 print 1+1                           ' Output: 2
 print cos(pi)                       ' Output: -1
@@ -19,7 +19,7 @@ print "Text"                        ' Output: Text
 
 ### Example 2: Print strings and numbers
 
-```
+```smallbasic
 print "abc" + "def"                 ' Output: adcdef
 print "abc" + " def"                ' Output: abc def
 print "abc" + 1 + "def" + cos(pi)   ' Output: abc1def-1
@@ -28,7 +28,7 @@ print "abc" + 1 + 2 + "def"         ' Output: abc12def  <- 1 and 2 are treated a
 
 ### Example 3: Print strings and variables
 
-```
+```smallbasic
 a = 1
 b = 2
 c = a + b
@@ -53,7 +53,7 @@ the output and at the same time evaluate expressions.
 
 ### Example 1: Using , and ;
 
-```
+```smallbasic
 a = 1
 b = 2
 print "a + b = " + a + b    ' Output: a + b = 12      <- a and b treated as strings
@@ -63,7 +63,7 @@ print "a + b = " , a + b    ' Output: a + b =      3  <- a + b was evaluated
 
 ### Example 2: Suppress new line
 
-```
+```smallbasic
 print "abc";     ' <- new line suppressed
 print "def"
 
@@ -72,7 +72,7 @@ print "def"
 
 ### Example 3: Using TAB and SPC
 
-```
+```smallbasic
 print "1" + tab(5) + "2"       ' Output 1    2
 print "1" + spc(1) + "2"       ' Output 1 2
 ```
@@ -89,7 +89,7 @@ See FORMAT for more information on how to define the format string.
 
 ### Example 1: Basic usage
 
-```
+```smallbasic
 a = 1000
 b = 2000
 PRINT USING "#,###.##"; a                    
@@ -103,7 +103,7 @@ PRINT USING "a = #####.00  b = #####"; a; b  ' <- One formated string with place
 
 ### Example 2: Apply format multiple times
 
-```
+```smallbasic
 a = 1000
 b = 2000
 PRINT USING "#,###.##"      ' Store format string
@@ -132,7 +132,7 @@ Escape codes can be used with PRINT. For more information please read the articl
 
 ### Example 1: 3 ways to print hello
 
-```
+```smallbasic
 ' 3 ways to print hello five time.bas 2016-03-05 SmallBASIC 0.12.2 [B+=MGA]
 'It's all in the punctuation at the end of a print statement
 
@@ -161,7 +161,7 @@ print "... this line needs to be finsihed."
 
 ### Example 2: Print to a file
 
-```
+```smallbasic
 Open "PRINT.TXT" For Output As #1
 Print #1, "hello"
 Close #1

--- a/_build/reference/536-console-sound.markdown
+++ b/_build/reference/536-console-sound.markdown
@@ -6,13 +6,13 @@ Plays a sound with the frequency `freg` in Hz for a duration `dur` in millisecon
 
 ### Example1 : Play sound
 
-```
+```smallbasic
 Sound 1000, 800, 50             ' 1000 Hz, 800 ms, 50% volume
 ```
 
 ### Example 2: Play sound in background
 
-```
+```smallbasic
 Sound 1000, 800, 50 BG          ' 1000 Hz, 800 ms, 50% volume
 print "This line will be printed immediately"
 pause

--- a/_build/reference/538-console-cat.markdown
+++ b/_build/reference/538-console-cat.markdown
@@ -16,7 +16,7 @@ Returns an escape code to format a string.
 
 For more information about escape codes please see the article "Escape codes".
 
-~~~
+```smallbasic
 Color 14, 1
 ? Cat(1); "This is Bold text"; Cat(-1)
 ?
@@ -28,6 +28,5 @@ Color 14, 1
 ? Cat(1); Cat(2); "This is Bold & Underline text"; Cat(0) 
 ?
 ? Cat(2); Cat(3); "This is Underline & Reverse text (with default colors)"; Cat(0)
-~~~
-
+```
 

--- a/_build/reference/539-console-inkey.markdown
+++ b/_build/reference/539-console-inkey.markdown
@@ -6,7 +6,7 @@ Returns the last key-code in keyboard buffer, or an empty string if there are no
 
 ### Example 1
 
-```
+```smallbasic
 WHILE(1)
   k = INKEY
   IF LEN(k)
@@ -24,7 +24,7 @@ WEND
 
 The following program will return the keycode and a string for every pressed key. The string can be used in an if-statement to querry if the key was pressed. See example 3 how to use the string.
 
-```
+```smallbasic
 while(1)
   k = INKEY
 
@@ -50,7 +50,7 @@ wend
 
 See example 2 to get the keycodes for the keys.
 
-```
+```smallbasic
 const KeyUp = chr(27) + chr(9)
 const KeyDown = chr(27) + chr(10)
 const KeySpace = " "
@@ -79,7 +79,7 @@ wend
 
 ### Example 4: Input form
 
-```
+```smallbasic
 ' Key values:
 Const K_BKSP   = Chr(0x08)  ' BackSpace
 Const K_TAB    = Chr(0x09)
@@ -170,7 +170,7 @@ Wend
 
 ### Example 5: A basic key code UNIT
 
-```
+```smallbasic
 REM Language:  SmallBASIC 0.12.6 (Linux 32-bit)
 REM Purpose:   Special key values returned by INKEY.
 REM            (Values returned by INKEY cannot be used for DEFINEKEY).

--- a/_build/reference/540-console-tab.markdown
+++ b/_build/reference/540-console-tab.markdown
@@ -6,7 +6,7 @@ Moves cursor position to the `n`th column. the return value `s` contains the esc
 
 ### Example
 
-```
+```smallbasic
 print tab(1); "1 tab"
 print tab(2); "2 tabs"
 

--- a/_build/reference/542-data-delete.markdown
+++ b/_build/reference/542-data-delete.markdown
@@ -10,7 +10,7 @@ Deletes 'count' elements at position 'idx' of array 'a'.
 
 Example 1: Delete element at position 2
 
-```
+```smallbasic
 a = [1,2,3,4,5]
 print a
 delete a, 2
@@ -19,7 +19,7 @@ print a
 
 Example 2: Delete two elements starting at position 2
 
-```
+```smallbasic
 b = [1,2,3,4,5]
 print b
 delete b, 2, 2

--- a/_build/reference/617-graphics-image.markdown
+++ b/_build/reference/617-graphics-image.markdown
@@ -8,40 +8,41 @@ The IMAGE statement provides access to extended support for image manipulation. 
 
 Create via open file handle
 
-```
+```smallbasic
 Open "circle.png" For Output As #1
 i = Image(#1)
 ```
 
 Create via file name
 
-```
+
+```smallbasic
 i = Image("circle.png")
 ```
 
 
 Create via URL (note only works with HTTP not HTTPS)
 
-```
+```smallbasic
 i = Image("http://pngimg.com/uploads/tesla_car/tesla_car_PNG26.png")
 ```
 
 Create via screen scrape (x, y, width, height)
 
-```
+```smallbasic
 i = Image(10, 10, 100, 100)
 ```
 
 Create via another image variable
 
-```
+```smallbasic
 k = Image(...)
 i = Image(k)
 ```
 
 Create via 2D array
 
-```
+```smallbasic
 'Create image array a1 without transparency
 dim a1(100, 200)
 For y = 0 To 99
@@ -76,7 +77,7 @@ i2.show(0,0)
 
 Create via array of [X_PixMap](https://en.wikipedia.org/wiki/X_PixMap) data
 
-```
+```smallbasic
 im << "16 18 4 1"
 im << "@ c #547B43"
 im << "  c #ffffff"
@@ -107,7 +108,7 @@ i = Image(im)
 
 zIndex controls whether the image will be displayed over or under another image. Images with higher zIndex values are drawn over the top of images with lower zIndex values. Opacity controls whether to display the image as solid or semi-transparent. Opacity values range from 1-100, with higher opacity values making the image less transparent. The default is 100 resulting in a solid image. When calling the show command a second time with new coordinates, the image will move to the new position.
 
-```
+```smallbasic
 i.show([x,y [,zindex [,opacity]]])
 ```
 
@@ -115,7 +116,7 @@ i.show([x,y [,zindex [,opacity]]])
 
 The hide command hides the image from display
 
-```
+```smallbasic
  i.hide()
 ```
 
@@ -123,7 +124,7 @@ The hide command hides the image from display
 
 The draw command draws the image immediately to the screen. Calling the draw command a second time with new coordinates, will draw the same image a second time at the new position to the screen.
 
-```
+```smallbasic
  i.draw([x,y [,opacity]])
 ```
 
@@ -131,7 +132,7 @@ The draw command draws the image immediately to the screen. Calling the draw com
 
 The save command saves the image data into the given file handle, file name or array
 
-```
+```smallbasic
 dim png
 i.save(png)
 ```
@@ -140,7 +141,7 @@ i.save(png)
 
 Reduces the size of the image.
 
-```
+```smallbasic
 png.clip(left, top, right, bottom)
 ```
 
@@ -148,7 +149,7 @@ png.clip(left, top, right, bottom)
 
 Calls the supplied callback function on each pixel
 
-```
+```smallbasic
 func colorToAlpha(x)
   return x
 end
@@ -159,14 +160,14 @@ png.filter(use colorToAlpha(x))
 
 Paste the given image into this image at the given x, y location
 
-```
+```smallbasic
 png2 = Image(w, h)
 png2.paste(png1, x, y)
 ```
 
 ### Example 1
 
-```
+```smallbasic
 Const CSI_EL = Chr(27) + "[K"  ' EL - Erase in Line (clear to end of line).
 Sub title(txt) 
   Locate 0, 0: Color 7, 0: ? CSI_EL; txt;
@@ -242,7 +243,7 @@ Pause
 
 ### Example 2
 
-```
+```smallbasic
 
 ' Notes: 
 ' 1. Using POINT and PSET is a much slower option then using:
@@ -295,7 +296,7 @@ Pause
 
 ### Example 3
 
-```
+```smallbasic
 
 ' Notes:
 ' 1. You may load an existing XPM image file, the same way you load PNG image
@@ -363,7 +364,7 @@ Pause
 
 ### Example 4
 
-```
+```smallbasic
 
 Color 7, 1: Cls              ' (for recognizing transparency color)
 ' --- [1]
@@ -453,7 +454,7 @@ Data "....................."
 
 ### Example 5
 
-```
+```smallbasic
 
 ' Dedicated to johnno56
 
@@ -515,7 +516,7 @@ Next layer
 
 ### Base64 decoder for example 4
 
-```
+```smallbasic
 
 REM Purpose:   A Base64 Encoder/Decoder UNIT.
 REM File name: base64.bas
@@ -705,7 +706,7 @@ End Func
 You may create a PNG image + transparency color with an external image editor, and then you may also decode it as a Base64 PNG string (to store it within the source code).
 Another useful option is to use XPM image format (See Part-3 above) with transparency color, instead of color number you just write NONE, like this:
 
-```
+```smallbasic
 a << "x c NONE"  ' Character "x" is transparency color
 ```
 
@@ -713,7 +714,7 @@ a << "x c NONE"  ' Character "x" is transparency color
 
 The following creates a plist file and composite sprite sheet which can be used with cocos2d development
 
-```
+```smallbasic
 const backgnd = 0xFF5A5D39
 const shadow = 0xFF080c08
 

--- a/_build/smallbasic.xml
+++ b/_build/smallbasic.xml
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language>
+<language name="smallbasic" version="1" kateversion="5.0" section="Sources" extensions="*.bas;*.BAS" casesensitive="no">
+  <highlighting>
+    <list name="preproc">    
+      <item>INCLUDE</item>
+      <item>IMPORT</item>
+      <item>EXPORT</item>
+      <item>OPTION</item>
+      <item>UNIT</item>    
+    </list>
+    
+    <list name="keywords">
+      <item>ACCESS</item>
+      <item>AND</item>
+      <item>APPEND</item>
+      <item>ARRAY</item>
+      <item>AS</item>
+      <item>BAND</item>
+      <item>BG</item>
+      <item>BOR</item>
+      <item>CASE</item>
+      <item>CATCH</item>
+      <item>DECLARE</item>
+      <item>DEF</item>
+      <item>DEFINEKEY</item>
+      <item>DO</item>
+      <item>ELIF</item>
+      <item>ELSE</item>
+      <item>ELSEIF</item>
+      <item>END</item>
+      <item>ENDIF</item>
+      <item>EQV</item>
+      <item>EXIT</item>
+      <item>FI</item>
+      <item>FOR</item>
+      <item>FUNC</item>
+      <item>GOSUB</item>
+      <item>GOTO</item>
+      <item>IF</item>
+      <item>IFF</item>
+      <item>IMP</item>
+      <item>IN</item>
+      <item>INKEY</item>
+      <item>INPUT</item>
+      <item>LABEL</item>
+      <item>LIKE</item>
+      <item>LOGPRINT</item>
+      <item>LSHIFT</item>
+      <item>MDL</item>
+      <item>MOD</item>
+      <item>NAND</item>
+      <item>NEXT</item>
+      <item>NOR</item>
+      <item>NOT</item>
+      <item>ON</item>
+      <item>OR</item>
+      <item>PAUSE</item>
+      <item>PRINT</item>
+      <item>PROGLINE</item>
+      <item>RANDOMIZE</item>
+      <item>REPEAT</item>
+      <item>RESTORE</item>
+      <item>RETURN</item>
+      <item>RSHIFT</item>
+      <item>SELECT</item>
+      <item>STOP</item>
+      <item>SUB</item>
+      <item>THEN</item>
+      <item>THROW</item>
+      <item>TO</item>
+      <item>TROFF</item>
+      <item>TRON</item>
+      <item>TRY</item>
+      <item>UNTIL</item>
+      <item>USE</item>
+      <item>USG</item>
+      <item>WEND</item>
+      <item>WHILE</item>
+      <item>XNOR</item>
+      <item>XOR</item>
+    </list>
+    
+    <list name="Data Types">  
+      <item>DIM</item>
+      <item>LOCAL</item>
+      <item>REDIM</item>      
+      <item>BYREF</item>
+      <item>CONST</item>
+      <item>DATA</item>
+      <item>EMPTY</item>
+      <item>FALSE</item>
+      <item>LET</item>
+      <item>NIL</item>
+      <item>PI</item>
+      <item>SELF</item>
+      <item>TRUE</item>
+      <item>XMAX</item>
+      <item>YMAX</item>
+      <item>MAXINT</item>
+    </list>   
+    
+    <list name="functions">
+      <item>ABS</item>
+      <item>ABSMAX</item>
+      <item>ABSMIN</item>
+      <item>ACOS</item>
+      <item>ACOSH</item>
+      <item>ACOT</item>
+      <item>ACOTH</item>
+      <item>ACSC</item>
+      <item>ACSCH</item>
+      <item>ARC</item>
+      <item>ASC</item>
+      <item>ASEC</item>
+      <item>ASECH</item>
+      <item>ASIN</item>
+      <item>ASINH</item>
+      <item>AT</item>
+      <item>ATAN</item>
+      <item>ATAN2</item>
+      <item>ATANH</item>
+      <item>ATN</item>
+      <item>BCS</item>
+      <item>BEEP</item>
+      <item>BGETC</item>
+      <item>BIN</item>
+      <item>BLOAD</item>
+      <item>BPUTC</item>
+      <item>BSAVE</item>
+      <item>CALL</item>
+      <item>CAT</item>
+      <item>CBS</item>
+      <item>CEIL</item>
+      <item>CHAIN</item>
+      <item>CHART</item>
+      <item>CHDIR</item>
+      <item>CHMOD</item>
+      <item>CHOP</item>
+      <item>CHR</item>
+      <item>CIRCLE</item>
+      <item>CLOSE</item>
+      <item>CLS</item>
+      <item>COLOR</item>
+      <item>COMMAND</item>
+      <item>COPY</item>
+      <item>COS</item>
+      <item>COSH</item>
+      <item>COT</item>
+      <item>COTH</item>
+      <item>CSC</item>
+      <item>CSCH</item>
+      <item>CWD</item>
+      <item>DATEDMY</item>
+      <item>DATEFMT</item>
+      <item>DEG</item>
+      <item>DELAY</item>
+      <item>DELETE</item>
+      <item>DERIV</item>
+      <item>DETERM</item>
+      <item>DIFFEQN</item>
+      <item>DIRWALK</item>
+      <item>DISCLOSE</item>
+      <item>DRAW</item>
+      <item>DRAWPOLY</item>
+      <item>ENCLOSE</item>
+      <item>ENV</item>
+      <item>EOF</item>
+      <item>ERASE</item>
+      <item>EXEC</item>
+      <item>EXP</item>
+      <item>EXPRSEQ</item>
+      <item>FILES</item>
+      <item>FIX</item>
+      <item>FLOOR</item>
+      <item>FORM</item>
+      <item>FORMAT</item>
+      <item>FRAC</item>
+      <item>FRE</item>
+      <item>FREEFILE</item>
+      <item>HEX</item>
+      <item>HOME</item>
+      <item>IMAGE</item>
+      <item>INSERT</item>
+      <item>INSTR</item>
+      <item>INT</item>
+      <item>INTERSECT</item>
+      <item>INVERSE</item>
+      <item>ISARRAY</item>
+      <item>ISDIR</item>
+      <item>ISFILE</item>
+      <item>ISLINK</item>
+      <item>ISMAP</item>
+      <item>ISNUMBER</item>
+      <item>ISSTRING</item>
+      <item>JOIN</item>
+      <item>JULIAN</item>
+      <item>KILL</item>
+      <item>LBOUND</item>
+      <item>LCASE</item>
+      <item>LEFT</item>
+      <item>LEFTOF</item>
+      <item>LEFTOFLAST</item>
+      <item>LEN</item>
+      <item>LINE</item>
+      <item>LINEINPUT</item>
+      <item>LINEQN</item>
+      <item>LINPUT</item>
+      <item>LOCATE</item>
+      <item>LOCK</item>
+      <item>LOF</item>
+      <item>LOG</item>
+      <item>LOG10</item>
+      <item>LOWER</item>
+      <item>LTRIM</item>
+      <item>M3APPLY</item>
+      <item>M3IDENT</item>
+      <item>M3ROTATE</item>
+      <item>M3SCALE</item>
+      <item>M3TRANS</item>
+      <item>MAX</item>
+      <item>MID</item>
+      <item>MIN</item>
+      <item>MKDIR</item>
+      <item>NOSOUND</item>
+      <item>OCT</item>
+      <item>OPEN</item>
+      <item>PAINT</item>
+      <item>PEN</item>
+      <item>PLAY</item>
+      <item>PLOT</item>
+      <item>POINT</item>
+      <item>POLYAREA</item>
+      <item>POLYCENT</item>
+      <item>POLYEXT</item>
+      <item>POW</item>
+      <item>PSET</item>
+      <item>PTDISTLN</item>
+      <item>PTDISTSEG</item>
+      <item>PTSIGN</item>
+      <item>RAD</item>
+      <item>READ</item>
+      <item>RECT</item>
+      <item>RENAME</item>
+      <item>REPLACE</item>
+      <item>RGB</item>
+      <item>RGBF</item>
+      <item>RIGHT</item>
+      <item>RIGHTOF</item>
+      <item>RIGHTOFLAST</item>
+      <item>RINSTR</item>
+      <item>RND</item>
+      <item>ROOT</item>
+      <item>ROUND</item>
+      <item>RTRIM</item>
+      <item>RUN</item>
+      <item>SBVER</item>
+      <item>SEARCH</item>
+      <item>SEC</item>
+      <item>SECH</item>
+      <item>SEEK</item>
+      <item>SEGCOS</item>
+      <item>SEGLEN</item>
+      <item>SEGSIN</item>
+      <item>SEQ</item>
+      <item>SETP</item>
+      <item>SGN</item>
+      <item>SHOWPAGE</item>
+      <item>SIN</item>
+      <item>SINH</item>
+      <item>SINPUT</item>
+      <item>SORT</item>
+      <item>SOUND</item>
+      <item>SPACE</item>
+      <item>SPC</item>
+      <item>SPRINT</item>
+      <item>SQR</item>
+      <item>SQUEEZE</item>
+      <item>STATMEAN</item>
+      <item>STATMEANDEV</item>
+      <item>STATMEDIAN</item>
+      <item>STATSPREADP</item>
+      <item>STATSPREADS</item>
+      <item>STATSTD</item>
+      <item>STKDUMP</item>    
+      <item>STR</item>
+      <item>STRING</item>
+      <item>SUM</item>
+      <item>SUMSQ</item>
+      <item>SWAP</item>
+      <item>TAB</item>
+      <item>TAN</item>
+      <item>TANH</item>
+      <item>TEXTHEIGHT</item>
+      <item>TEXTWIDTH</item>
+      <item>TICKS</item>
+      <item>TIME</item>
+      <item>TIMEHMS</item>
+      <item>TIMER</item>
+      <item>TLOAD</item>
+      <item>TRANSLATE</item>
+      <item>TRIM</item>
+      <item>TSAVE</item>
+      <item>TXTH</item>
+      <item>TXTW</item>
+      <item>UBOUND</item>
+      <item>UCASE</item>
+      <item>UPPER</item>
+      <item>VAL</item>
+      <item>VIEW</item>
+      <item>WEEKDAY</item>
+      <item>WINDOW</item>
+      <item>WRITE</item>
+      <item>XPOS</item>
+      <item>YPOS</item>    
+    </list>
+
+    <contexts>
+      <context attribute="Normal Text" lineEndContext="#stay" name="Normal">
+
+        <RegExpr attribute="Keyword" context="#stay" String="\b(exit (func|sub|for|do|while|select)|declare (function|sub))([\s]|$)" insensitive="true" />
+
+        <RegExpr attribute="Keyword" context="#stay" String="\b(while)([(\s)]|$)" insensitive="true" beginRegion="WhileRegion"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\b(wend)([\s]|$)" insensitive="true" endRegion="WhileRegion"/>
+        
+        <RegExpr attribute="Keyword" context="#stay" String="\b(repeat)([\s]|$)" insensitive="true" beginRegion="DoRegion"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\b(until)([(\s)]|$)" insensitive="true" endRegion="DoRegion"/>
+
+        <RegExpr attribute="Keyword" context="#stay" String="\b(select case)([\s]|$)" insensitive="true" beginRegion="SelectRegion"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\b(end select)([\s]|$)" insensitive="true" endRegion="SelectRegion"/>
+
+        <RegExpr attribute="Keyword" context="#stay" String="\b(for (input|output|append))([\s]|$)" insensitive="true" />
+                
+        <RegExpr attribute="Keyword" context="#stay" String="\b(for)([(\s)]|$)" insensitive="true" beginRegion="ForRegion"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\b(next)([\s]|$)" insensitive="true" endRegion="ForRegion"/>
+
+        <RegExpr attribute="Keyword" context="#stay" String="\b(func)([.\s]|$)" insensitive="true" beginRegion="fProcedureRegion"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\b(end func|end)([\s]|$)" insensitive="true" endRegion="fProcedureRegion"/>
+        
+        <RegExpr attribute="Keyword" context="#stay" String="\b(sub)([.\s]|$)" insensitive="true" beginRegion="sProcedureRegion"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\b(end sub|end)([\s]|$)" insensitive="true" endRegion="sProcedureRegion"/>
+
+        <RegExpr attribute="Keyword" context="#stay" String="\b(if)([(\s)]|$)" insensitive="true" beginRegion="IfRegion"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\b(then )[a-zA-Z_\x7f-\xff].|\b(fi|endif)([\s]|$)" insensitive="true" endRegion="IfRegion"/>
+
+        <keyword attribute="Keyword" context="#stay" String="keywords"/>
+        <keyword attribute="Data Types" context="#stay" String="Data Types"/>
+        <keyword attribute="Preprocessor" context="#stay" String="preproc"/>
+         
+        <keyword attribute="Functions" context="#stay" String="functions"/>
+        <RegExpr attribute="Constant" context="#stay" String="\#+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"/>
+        <Float attribute="Number" context="#stay"/>
+        <Int attribute="Number" context="#stay"/>
+        <DetectChar attribute="String" context="String" char="&quot;" />
+        <RegExpr attribute="Region Marker" context="#stay" String="^\s*;+\s*BEGIN.*$" beginRegion="marker" column="0"/>
+        <RegExpr attribute="Region Marker" context="#stay" String="^\s*;+\s*END.*$" endRegion="marker" column="0"/>
+        <DetectChar attribute="Comment" context="Comment1" char="'"/>
+        <RegExpr attribute="Comment" context="Comment1" String="\b(rem)([.\s]|$)" insensitive="true"/>
+      </context>
+      <context attribute="String" lineEndContext="#pop" name="String">
+        <DetectChar attribute="String" context="#pop" char="&quot;"/>
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="Comment1">
+        <IncludeRules context="##Comments" />
+      </context>
+    </contexts>
+    <itemDatas>
+      <itemData name="Normal Text" defStyleNum="dsNormal"/>
+      <itemData name="Keyword" defStyleNum="dsKeyword"/>
+      <itemData name="Functions" defStyleNum="dsFunction"/>
+      <itemData name="Data Types" defStyleNum="dsDataType"/>
+      <itemData name="Constant" defStyleNum="dsConstant"/>
+      <itemData name="Number" defStyleNum="dsDecVal"/>
+      <itemData name="String" defStyleNum="dsString"/>
+      <itemData name="Comment" defStyleNum="dsComment"/>
+      <itemData name="Region Marker" defStyleNum="dsRegionMarker"/>
+      <itemData name="Preprocessor" defStyleNum="dsPreprocessor"/>
+    </itemDatas>
+  </highlighting>
+  <general>
+    <keywords casesensitive="0" />
+  </general>
+</language>
+<!-- // kate: space-indent on; indent-width 2; replace-tabs on; --> 

--- a/css/style.css
+++ b/css/style.css
@@ -690,3 +690,78 @@ div.date > div:before {
   content: "\1f558";
   padding-right: .5em;
 }
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+    width: 0.8em;
+    margin: 0 0.8em 0.2em -1.6em;
+    vertical-align: middle;
+}
+.display.math{display: block; text-align: center; margin: 0.5rem auto;}
+/* CSS for syntax highlighting */
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+    div.sourceCode { overflow: auto; }
+    }
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+    { counter-reset: source-line 0; }
+pre.numberSource code > span
+    { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+    { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+    }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+    {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { color: #008000; } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { color: #008000; font-weight: bold; } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; }


### PR DESCRIPTION
Hi Chris,

when building the website pandoc will create syntax highlighting now. This was quite easy to implement, because pandoc supports KDE syntax-highlighting definitions. The only thing I needed to do was to provide the Kate syntax-highlighting file, I created a while ago. For every code-block in the markdown files a "smallbasic" tag has to be added. For testing I did this for some files. I added the necessary style-sheets for syntax highlighting to the css/style.css file.  I tested the html-files with the simple python http server. I hope that in the real world it will work, too. 
Next step would be to add the smallbasic-tag to all markdown files. Maybe there is a smart way using console commands in Linux.

Best regards, Joerg